### PR TITLE
Fix empty unreleased section updates (date bug)

### DIFF
--- a/doculog/__init__.py
+++ b/doculog/__init__.py
@@ -1,3 +1,3 @@
 from doculog.changelog import ChangelogDoc
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/doculog/changelog.py
+++ b/doculog/changelog.py
@@ -271,8 +271,10 @@ class ChangelogUnreleased(ChangelogRelease):
     """
 
     def __init__(self) -> None:
-        # Use some far future date to get all unrelesaed commits
-        super().__init__("Unreleased", "2100-12-31")
+        # Use some far future date to get all unreleased commits
+        # Some dates, e.g. 2100-12-31, yield 0 commits.
+        # TODO: Need to work out why
+        super().__init__("Unreleased", "2099-01-01")
 
     def header(self) -> str:
         return f"## {self._version}"


### PR DESCRIPTION
The "unreleased" section gets commits from the date of the last release to some date in the future. This used to be 2100-12-31, but for some reason this began to yield empty git logs. Therefore, this future date was changed to 2099-01-01, which seems to work. This is a temporary workaround and should be fixed properly separate to this PR. 