### PR TITLE
Hotfix/windows cli

### DIFF
--- a/doculog/__init__.py
+++ b/doculog/__init__.py
@@ -1,3 +1,3 @@
 from doculog.changelog import ChangelogDoc
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [tool.isort]
 profile = "black"
 
+[tool.documatic]
+name = "Doculog"
+srcdir = "doculog"
+docdir = "."
+
 [tool.doculog]
 changelog = "CHANGELOG"
 local = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,3 @@ packages = find:
 install_requires =
     requests
     python-dotenv
-
-[options.entry_points]
-console_scripts =
-    doculog = doculog.main:generate_changelog

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,9 @@ def get_version():
 
 setup(
     version=get_version(),
+    entry_points={
+        "console_scripts": [
+            "doculog=doculog.main:generate_changelog",
+        ]
+    },
 )


### PR DESCRIPTION
Moves console scripts to setup py so setuptools can build CLIs for windows (which are currently broken)