### PR TITLE
Improve API key error messaging

### DIFF
--- a/doculog/__init__.py
+++ b/doculog/__init__.py
@@ -1,3 +1,3 @@
 from doculog.changelog import ChangelogDoc
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/doculog/config.py
+++ b/doculog/config.py
@@ -27,11 +27,9 @@ def configure(project_root: Path) -> Dict:
 def configure_api(local):
     if (not local) and (not validate_key()):
         if "DOCUMATIC_API_KEY" in os.environ:
-            print("DOCUMATIC_API_KEY invalid. Advanced features disabled")
             del os.environ["DOCUMATIC_API_KEY"]
 
         if "DOCULOG_API_KEY" in os.environ:
-            print("DOCULOG_API_KEY invalid. Advanced features disabled.")
             del os.environ["DOCULOG_API_KEY"]
 
 

--- a/doculog/config.py
+++ b/doculog/config.py
@@ -36,6 +36,7 @@ def configure_api(local):
 
 
 def parse_config(project_root: Path) -> Dict:
+    print(f"Reading environment variables from {project_root / '.env.'}")
     load_dotenv(project_root / ".env")
 
     DEFAULT_VARS = {

--- a/doculog/requests.py
+++ b/doculog/requests.py
@@ -97,6 +97,7 @@ def validate_key() -> bool:
     api_key = os.getenv("DOCUMATIC_API_KEY") or os.getenv("DOCULOG_API_KEY")
 
     if not api_key:
+        print("DOCUMATIC_API_KEY not in environment")
         return False
 
     if os.getenv("DOCULOG_RUN_LOCALLY") != "False":
@@ -107,7 +108,7 @@ def validate_key() -> bool:
         response = requests.get(
             SERVER_DOMAIN + "validate",
             params={"project": hashed_project},
-            headers={"x-api-key": api_key},
+            headers={"x-api-key": api_key, "content-type": "application/json"},
         )
     except requests.exceptions.ConnectionError:
         return False
@@ -117,8 +118,8 @@ def validate_key() -> bool:
     else:
         if response.status_code == 403:
             print(
-f"""\nAPI call error: {response.headers['x-amzn-errortype']}.
+                f"""\nAPI call error: {response.headers['x-amzn-errortype']}.
 Please file a bug report if this is unexpected.
 doculog can still run, but without advanced features.\n"""
-)
+            )
         return False

--- a/doculog/requests.py
+++ b/doculog/requests.py
@@ -115,4 +115,10 @@ def validate_key() -> bool:
     if response.status_code == 200:
         return response.json()["message"]
     else:
+        if response.status_code == 403:
+            print(
+f"""\nAPI call error: {response.headers['x-amzn-errortype']}.
+Please file a bug report if this is unexpected.
+doculog can still run, but without advanced features.\n"""
+)
         return False

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -57,6 +57,24 @@ class TestValidateKey:
         assert validate_key() is is_valid
         assert len(responses.calls) == 1
 
+    @responses.activate
+    @mock.patch.dict(
+        os.environ, {"DOCUMATIC_API_KEY": "12345", "DOCULOG_RUN_LOCALLY": "False"}
+    )
+    def test_returns_validated_response_with_documatic_api_key_but_not_doculog(self):
+        if "DOCULOG_API_KEY" in os.environ:
+            del os.environ["DOCULOG_API_KEY"]
+
+        responses.add(
+            responses.GET,
+            SERVER_DOMAIN + "validate",
+            status=200,
+            json={"message": True},
+        )
+
+        assert validate_key() is True
+        assert len(responses.calls) == 1
+
 
 class TestPost:
     @responses.activate


### PR DESCRIPTION
*This PR:**

- Prints the error message from a 403 API call
- Sets the validation request content type to application/json
  - No particular reason, but doing this just in case it's an os specific issue with a different default content type

Related to #25 